### PR TITLE
Close the still showing video callout

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -20,6 +20,17 @@ const hideSelfButton = () =>
     )
     .iterateNext();
 
+const closeSendingVideoButton = () =>
+  document
+    .evaluate(
+      "//button[i[contains(., 'close')]]",
+      document,
+      null,
+      XPathResult.ANY_TYPE,
+      null
+    )
+    .iterateNext();
+
 const isElementVisible = (el) => el.offsetParent === null;
 
 const areOthersInTheCall = () =>
@@ -35,5 +46,8 @@ const interval = setInterval(() => {
     console.log("Hiding self...");
     clearInterval(interval);
     hideSelfButton().click();
+    setTimeout(() => {
+      closeSendingVideoButton().click();
+    }, 4000);
   }
 }, 2000);


### PR DESCRIPTION
This waits 2 seconds and then also closes the callout that tells you you're still sending video.