### PR TITLE
Adjust for minimize being moved in Meet

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -12,7 +12,18 @@ const isOnJoinPage = () =>
 const hideSelfButton = () =>
   document
     .evaluate(
-      "//div[following-sibling::span//i[contains(., 'close_fullscreen')]]",
+      "//span[i[contains(., 'close_fullscreen')]]",
+      document,
+      null,
+      XPathResult.ANY_TYPE,
+      null
+    )
+    .iterateNext();
+
+const moreButton = () =>
+  document
+    .evaluate(
+      "//button[i[contains(., 'more_vert')]]",
       document,
       null,
       XPathResult.ANY_TYPE,
@@ -45,7 +56,10 @@ const interval = setInterval(() => {
   if (areOthersInTheCall()) {
     console.log("Hiding self...");
     clearInterval(interval);
-    hideSelfButton().click();
+    moreButton().click();
+    setTimeout(() => {
+      hideSelfButton().click();
+    });
     setTimeout(() => {
       closeSendingVideoButton().click();
     }, 4000);

--- a/contentScript.js
+++ b/contentScript.js
@@ -23,7 +23,7 @@ const hideSelfButton = () =>
 const moreButton = () =>
   document
     .evaluate(
-      "//button[i[contains(., 'more_vert')]]",
+      "//i[contains(., 'auto_awesome')]/following::i[contains(., 'more_vert')]",
       document,
       null,
       XPathResult.ANY_TYPE,

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Hide self in Google Meet",
   "description": "Automatically hide your self view in Google Meet - better for your mental health!",
-  "version": "1.2",
+  "version": "1.3",
   "manifest_version": 3,
   "icons": {
     "16": "images/icon@16px.png",


### PR DESCRIPTION
Recently, Google moved the button to minimize you video to a submenu, breaking the functionality of this extension.

This submenu needs to be opened before the self-view can be minimized. This makes adjustments to restore the functionality.